### PR TITLE
adding code for masking and cleaned/masked fine-tuning data

### DIFF
--- a/Fine Tuning/masking/mask_r_code.ipynb
+++ b/Fine Tuning/masking/mask_r_code.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(\"bioinformatics_workshop_gitbook.json\", \"r\", encoding=\"utf-8\") as file:\n",
+    "    data = json.load(file)\n",
+    "\n",
+    "workshop_codes = [entry[\"code\"] for entry in data if \"code\" in entry]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(\"r_package_data.json\", \"r\", encoding=\"utf-8\") as file:\n",
+    "    data = json.load(file)\n",
+    "\n",
+    "example_values = []\n",
+    "for package, details in data.items():\n",
+    "    if \"examples\" in details:\n",
+    "        example_values.extend(details[\"examples\"].values())\n",
+    "\n",
+    "packages_codes = example_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'# Default histogram display\\nggplot(mpg, aes(displ)) +\\n  geom_histogram(aes(y = after_stat(count)))\\n\\n# Scale tallest bin to 1\\nggplot(mpg, aes(displ)) +\\n  geom_histogram(aes(y = after_stat(count / max(count))))\\n\\n# Use a transparent version of colour for fill\\nggplot(mpg, aes(class, hwy)) +\\n  geom_boxplot(aes(colour = class, fill = after_scale(alpha(colour, 0.4))))\\n\\n# Use stage to modify the scaled fill\\nggplot(mpg, aes(class, hwy)) +\\n  geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))\\n\\n# Making a proportional stacked density plot\\nggplot(mpg, aes(cty)) +\\n  geom_density(\\n    aes(\\n      colour = factor(cyl),\\n      fill = after_scale(alpha(colour, 0.3)),\\n      y = after_stat(count / sum(n[!duplicated(group)]))\\n    ),\\n    position = \"stack\", bw = 1\\n  ) +\\n  geom_density(bw = 1)\\n\\n# Imitating a ridgeline plot\\nggplot(mpg, aes(cty, colour = factor(cyl))) +\\n  geom_ribbon(\\n    stat = \"density\", outline.type = \"upper\",\\n    aes(\\n      fill = after_scale(alpha(colour, 0.3)),\\n      ymin = after_stat(group),\\n      ymax = after_stat(group + ndensity)\\n    )\\n  )\\n\\n# Labelling a bar plot\\nggplot(mpg, aes(class)) +\\n  geom_bar() +\\n  geom_text(\\n    aes(\\n      y = after_stat(count + 2),\\n      label = after_stat(count)\\n    ),\\n    stat = \"count\"\\n  )\\n\\n# Labelling the upper hinge of a boxplot,\\n# inspired by June Choe\\nggplot(mpg, aes(displ, class)) +\\n  geom_boxplot(outlier.shape = NA) +\\n  geom_text(\\n    aes(\\n      label = after_stat(xmax),\\n      x = stage(displ, after_stat = xmax)\\n    ),\\n    stat = \"boxplot\", hjust = -0.5\\n  )'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "packages_codes[3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(\"bioconductor_r_code.json\", \"r\", encoding=\"utf-8\") as file:\n",
+    "    data = json.load(file)\n",
+    "\n",
+    "bioconductor_files = []\n",
+    "for package, files in data.items():\n",
+    "    for file_name, code in files.items():\n",
+    "        bioconductor_files.append(code)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_codes = workshop_codes + packages_codes + bioconductor_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JSON file 'LLM_output_codes.json' has been created with 3763 formatted entries.\n"
+     ]
+    }
+   ],
+   "source": [
+    "json_entries = [{\"output\": entry} for entry in input_codes]\n",
+    "\n",
+    "output_file = \"LLM_output_codes.json\"\n",
+    "with open(output_file, \"w\", encoding=\"utf-8\") as file:\n",
+    "    json.dump(json_entries, file, indent=4, ensure_ascii=False)\n",
+    "\n",
+    "print(f\"JSON file '{output_file}' has been created with {len(json_entries)} formatted entries.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 3599 hole-punched training samples.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import random\n",
+    "\n",
+    "with open(\"LLM_output_codes.json\", \"r\", encoding=\"utf-8\") as file:\n",
+    "    data = json.load(file)\n",
+    "\n",
+    "def create_hole_punched_samples(data):\n",
+    "    masked_data = []\n",
+    "    \n",
+    "    for entry in data:\n",
+    "        code = entry[\"output\"]\n",
+    "        \n",
+    "        lines = code.split(\"\\n\")\n",
+    "\n",
+    "        if len(lines) > 1:\n",
+    "            strategy = random.choice([\"line_removal\", \"multi_line_removal\", \"substring_removal\"])\n",
+    "\n",
+    "            if strategy == \"line_removal\":\n",
+    "                valid_lines = [line for line in lines if not line.strip().startswith(\"#\")]\n",
+    "                if valid_lines:\n",
+    "                    line_to_remove = random.choice(valid_lines)\n",
+    "                    masked_code = code.replace(line_to_remove, \"____\", 1)\n",
+    "                    masked_data.append({\"input\": masked_code, \"output\": line_to_remove})\n",
+    "                    continue \n",
+    "\n",
+    "            elif strategy == \"multi_line_removal\" and len(lines) > 3:\n",
+    "                start_idx = random.randint(0, len(lines) - 3)\n",
+    "                lines_to_remove = lines[start_idx : start_idx + random.randint(2, 3)]\n",
+    "                masked_code = code.replace(\"\\n\".join(lines_to_remove), \"____\", 1)\n",
+    "                masked_data.append({\"input\": masked_code, \"output\": \"\\n\".join(lines_to_remove)})\n",
+    "                continue\n",
+    "\n",
+    "        words = code.split()\n",
+    "        if len(words) > 5: \n",
+    "            snippet_to_remove = \" \".join(random.sample(words, min(4, len(words)))) \n",
+    "            masked_code = code.replace(snippet_to_remove, \"____\", 1)\n",
+    "            masked_data.append({\"input\": masked_code, \"output\": snippet_to_remove})\n",
+    "    \n",
+    "    return masked_data\n",
+    "\n",
+    "masked_samples = create_hole_punched_samples(data)\n",
+    "\n",
+    "output_file = \"fixed_masked_training_data.json\"\n",
+    "with open(output_file, \"w\", encoding=\"utf-8\") as file:\n",
+    "    json.dump(masked_samples, file, indent=4)\n",
+    "\n",
+    "print(f\"Generated {len(masked_samples)} hole-punched training samples.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Fixes #17 

**What was changed?**

I created a script to combine the three R datasets that we perviously collected from bioconductor, R packages, and online tutorials to prepare them for finetuning. In addition to combining these datasets, I also masked each of the code snippets to create input data and output labels and saved these out to a file. 

**Why was it changed?**

In order to finetune the CodeT5 model for code generation tasks on R code, our dataset needs to be structured in such a way where the input data is the full code snippet with some of the code removed and the training label is the removed bit of code. So, I performed a masking operation on each code snippet that structures our dataset in the previously described format. 

**How was it changed?**

I added a jupyter notebook titled `mask_r_code.ipynb` that combines all three datasets that were previously collected (bioconductor, R packages, and online tutorials). It also performs a masking operation using the hole-punch methodology where either one line, multiple lines, or a substring of characters is removed from the code snippet. Then, the remaining code becomes the training example and the removed code becomes the training label. The input and label are saved in a file titled `fixed_masked_training_data.json` labeled as either "input" or "output". 
